### PR TITLE
ci: Adapt dependabot commit message format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "build"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "build"

--- a/.github/workflows/build-release-master.yaml
+++ b/.github/workflows/build-release-master.yaml
@@ -51,6 +51,7 @@ jobs:
         run: npx semantic-release
 
       - name: Log in to Container registry
+        if: ${{ env.NEXT_RELEASE_VERSION != '' }}
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -58,6 +59,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for docker
+        if: ${{ env.NEXT_RELEASE_VERSION != '' }}
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -68,6 +70,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
+        if: ${{ env.NEXT_RELEASE_VERSION != '' }}
         uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
The dependabot commit message format must adhere to the angular commit message formatting rules, so the correct release will be trigger for changes by dependabot.

resolves #38