### PR TITLE
ci: update actions/checkout to v3

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -9,9 +9,7 @@ jobs:
   builds:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -9,9 +9,7 @@ jobs:
   builds:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-release-master.yaml
+++ b/.github/workflows/build-release-master.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Update checkout action to v3 and remove superfluous/erroneous with-depth setting. The action performs a shallow clone by default.

resolves #37